### PR TITLE
feat: add dockercompose to run middleman server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Dockerfile
+
+FROM ruby:2.3.1
+
+WORKDIR /app
+
+RUN curl -sL https://deb.nodesource.com/setup_13.x -o nodesource_setup.sh  && \
+    bash nodesource_setup.sh && \
+    apt install -y --force-yes nodejs
+
+COPY Gemfile Gemfile.lock ./
+
+RUN bundle install --without debug && npm install
+
+EXPOSE 4567

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.7'
+
+services: 
+  web:
+    build: .
+    command: bundle exec middleman server --watcher-force-polling --watcher-latency=1 &> ~/middleman.log 
+
+    volumes:
+      - '.:/app'
+      - 'node_modules:/app/node_modules'
+    ports:
+      - '4567:4567'
+      - '1234:1234'
+volumes: 
+  node_modules:


### PR DESCRIPTION
Make it possible to run the middleman server using docker as an alternative to Vagrant.

* Create a dockerfile
* Create a docker-compose