### PR TITLE
fix/rename_payout_account_into_financial_account

### DIFF
--- a/source/includes/financial/financial_accounts/_financial_account_detalhes.md
+++ b/source/includes/financial/financial_accounts/_financial_account_detalhes.md
@@ -1,16 +1,16 @@
-## Detalhes de Conta de Recebimento
+## Detalhes de Conta Digital
 
-Mostra detalhes de uma Conta de Recebimento
+Mostra detalhes de uma Conta Digital
 
 
 <div class="api-endpoint">
   <div class="endpoint-data">
     <i class="label label-get">GET</i>
-     api/v1/organizations/{organization_id}/payout_accounts/{id}
+     api/v1/organizations/{organization_id}/financial_accounts/{id}
   </div>
 </div>
 
-Exemplo: api/v1/organizations/123/payout_accounts/1
+Exemplo: api/v1/organizations/123/financial_accounts/1
 
 > Exemplo de Corpo
 
@@ -22,7 +22,7 @@ Exemplo: api/v1/organizations/123/payout_accounts/1
 
 ```json
 {
-  "payout_account": {
+  "financial_account": {
     "id": 1,
     "status": "processing",
     "bank_code": "341",

--- a/source/includes/financial/financial_accounts/_financial_accounts.md
+++ b/source/includes/financial/financial_accounts/_financial_accounts.md
@@ -1,0 +1,1 @@
+# Contas Digitais

--- a/source/includes/financial/financial_accounts/_financial_accounts_list.md
+++ b/source/includes/financial/financial_accounts/_financial_accounts_list.md
@@ -1,15 +1,15 @@
-## Lista de Contas de Recebimento
+## Lista de Contas Digitais
 
-Lista todos as contas de recebimento de uma organização
+Lista todos as contas de digitais de uma organização
 
 <div class="api-endpoint">
   <div class="endpoint-data">
     <i class="label label-get">GET</i>
-     api/v1/organizations/{organization_id}/payout_accounts
+     api/v1/organizations/{organization_id}/financial_accounts
   </div>
 </div>
 
-Exemplo: api/v1/organizations/123/payout_accounts
+Exemplo: api/v1/organizations/123/financial_accounts
 > Exemplo de Corpo
 
 ```json
@@ -20,7 +20,7 @@ Exemplo: api/v1/organizations/123/payout_accounts
 
 ```json
 {
-  "payout_accounts":
+  "financial_accounts":
   [
     {
       "id": 1,

--- a/source/includes/financial/payout_accounts/_payout_accounts.md
+++ b/source/includes/financial/payout_accounts/_payout_accounts.md
@@ -1,1 +1,0 @@
-# Contas de Recebimento

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -111,9 +111,9 @@ includes:
   - financial/charge_templates/charge_templates
   - financial/charge_templates/charge_template_detalhes
   - financial/charge_templates/charge_templates_list
-  - financial/payout_accounts/payout_accounts
-  - financial/payout_accounts/payout_account_detalhes
-  - financial/payout_accounts/payout_accounts_list
+  - financial/financial_accounts/financial_accounts
+  - financial/financial_accounts/financial_account_detalhes
+  - financial/financial_accounts/financial_accounts_list
 
 search: true
 ---


### PR DESCRIPTION
Change the payout account endpoint into financial_account, because it is responsible for listing all types of financial accounts.