### PR TITLE
feat/BIL-3513: add charge now to invoice endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,23 @@
 # Dockerfile
 
-FROM ruby:2.6.0
+FROM ruby:2.6-bullseye
 
 WORKDIR /app
 
-RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
+# Install system dependencies
+RUN apt-get update \
+ && apt-get install -y nodejs npm \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
-RUN curl -sL https://deb.nodesource.com/setup_13.x -o nodesource_setup.sh  && \
-    bash nodesource_setup.sh && \
-    apt install -y --force-yes nodejs
-
+# Copy dependency files
 COPY Gemfile Gemfile.lock ./
 
-RUN gem install bundler:2.3.21 && bundle install --without debug && npm install
+# Install Ruby gems and Node packages
+# Use modern bundler config instead of deprecated --without flag
+RUN gem install bundler:2.3.21 \
+ && bundle config set --local without 'debug' \
+ && bundle install \
+ && npm install
 
 EXPOSE 4567

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby '2.6.0'
+ruby '~> 2.6.0'
 source 'https://rubygems.org'
 
 # Middleman

--- a/README.md
+++ b/README.md
@@ -10,6 +10,34 @@
 
 <p align="center"><em>The example above was created with Slate. Check it out at <a href="https://lord.github.io/slate">lord.github.io/slate</a>.</em></p>
 
+---
+
+## Fintera Faturamento API Documentation
+
+This repository contains the API documentation for **Fintera Faturamento**, a Brazilian billing system.
+
+### Quick Start with Docker (Recommended)
+
+**Prerequisites:** Docker and Docker Compose installed on your system.
+
+```bash
+# Clone the repository
+git clone <repository-url>
+cd billimatic-api-docs
+
+# Start the development server
+docker-compose up
+
+# Access the documentation
+open http://localhost:4567
+```
+
+The documentation will auto-reload when you make changes to the Markdown files.
+
+**For detailed development instructions, troubleshooting, and coding guidelines**, see [AGENTS.md](AGENTS.md).
+
+---
+
 Features
 ------------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,17 @@
-version: '3.7'
-
 services: 
   web:
     build: .
-    command: bundle exec middleman server --watcher-force-polling --watcher-latency=1 &> ~/middleman.log 
-
+    command: bundle exec middleman server --bind-address=0.0.0.0 --watcher-force-polling --watcher-latency=1
+    
     volumes:
       - '.:/app'
       - 'node_modules:/app/node_modules'
     ports:
       - '4567:4567'
-      - '1234:1234'
+      - '35729:35729'
+    
+    environment:
+      - MIDDLEMAN_ENV=development
+
 volumes: 
   node_modules:

--- a/source/includes/invoices/_inv_campos.md
+++ b/source/includes/invoices/_inv_campos.md
@@ -40,7 +40,19 @@
 | attachments (Attachment, optional)                      | Anexos (Array)                                                                    |
 | payment_information (PaymentInformation, optional)      | Informações de pagamento                                                          |
 | issue_nfse (boolean, optional)                          | Emitir nota fiscal                                                                |
+| charge_now (boolean, optional)                          | Se deve disparar o processo de cobrança imediatamente                             |
 | invoice_template_id (integer, optional)                 | ID do modelo de faturamento (É obrigatório ter periodicidade "uma única vez")     |
+
+<br>
+<strong> Importante sobre charge_now </strong>
+
+O campo `charge_now` funciona **apenas** para contratos com gestão automática (`management_type: 'automatic'`) e método de pagamento boleto (`payment_method: 'billet'`). 
+
+Quando definido como `true`, dispara um job em segundo plano que inicia o processo de cobrança imediatamente após a criação do faturamento.
+
+**Valor padrão:** `false` (não dispara cobrança imediata)
+
+**Caso de uso:** Útil quando o cliente precisa do `billet_url` (URL do boleto) o mais rápido possível, sem aguardar o processamento padrão.
 
 * Possibilidades
 Campo: approval_status poderá conter:  'approved' para aprovado, 'blocked' para bloqueado (apenas para criação de faturamentos)

--- a/source/includes/invoices/_inv_cria.md
+++ b/source/includes/invoices/_inv_cria.md
@@ -38,6 +38,7 @@ Cria um faturamento
     "cobrato_charge_template_name": "",
     "days_until_automatic_nfe_emission": 0,
     "issue_nfse": false,
+    "charge_now": false,
     "comments": "",
     "invoice_template_id": 1,
     "receivables": [


### PR DESCRIPTION
## O que esta PR faz?
- Documenta o novo atributo `charge_now`, responsável por identificar se o processo de cobrança deve ser disparado imediatamente após a criação
- Atualizar ambiente de desenvolvimento
<img width="1231" height="357" alt="image" src="https://github.com/user-attachments/assets/f9743c7e-485e-455c-9d2a-f31e3711f159" />
